### PR TITLE
Limit ex_doc dependency to :dev

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -34,6 +34,6 @@ defmodule XmlBuilder.Mixfile do
   #
   # Type `mix help deps` for more examples and options
   defp deps do
-    [{:ex_doc, github: "elixir-lang/ex_doc"}]
+    [{:ex_doc, github: "elixir-lang/ex_doc", only: :docs}]
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -34,6 +34,6 @@ defmodule XmlBuilder.Mixfile do
   #
   # Type `mix help deps` for more examples and options
   defp deps do
-    [{:ex_doc, github: "elixir-lang/ex_doc", only: :docs}]
+    [{:ex_doc, github: "elixir-lang/ex_doc", only: :dev}]
   end
 end


### PR DESCRIPTION
ex_doc is listed as a dependency, but it's listed as required for running `xml_builder` which isn't true - having it like this causes issues when a project that depends on it specifies a certain version of ex_doc