### PR TITLE
Handling text nodes properly.

### DIFF
--- a/lib/xml_builder.ex
+++ b/lib/xml_builder.ex
@@ -17,8 +17,6 @@ defmodule XmlBuilder do
       "<person occupation=\\\"Developer\\\">Josh</person>"
   """
 
-  ##############################################################################
-
   defmacrop is_blank_attrs(attrs) do
     quote do: is_nil(unquote(attrs)) or map_size(unquote(attrs)) == 0
   end
@@ -38,9 +36,7 @@ defmodule XmlBuilder do
   def doc(name, attrs, content),
     do: [:_doc_type | [element(name, attrs, content)]] |> generate
 
-  ##############################################################################
-
-  def element(name) when is_binary(name),
+  def element(name) when is_bitstring(name),
     do: element({nil, nil, name})
 
   def element(name) when is_bitstring(name) or is_atom(name),
@@ -73,18 +69,19 @@ defmodule XmlBuilder do
   def element(name, attrs, content),
     do: element({name, attrs, content})
 
-  ##############################################################################
-
   def generate(any),
     do: generate(any, 0)
 
   def generate(:_doc_type, 0),
     do: ~s|<?xml version="1.0" encoding="UTF-8" ?>|
 
+  def generate(string, level) when is_bitstring(string),
+    do: generate({nil, nil, string}, level)
+
   def generate(list, level) when is_list(list),
     do: list |> Enum.map(&(generate(&1, level))) |> Enum.intersperse("\n") |> Enum.join
 
-  def generate({nil, nil, name}, level) when is_binary(name),
+  def generate({nil, nil, name}, level) when is_bitstring(name),
     do: "#{indent(level)}#{name}"
 
   def generate({name, attrs, content}, level) when is_blank_attrs(attrs) and is_blank_list(content),
@@ -105,12 +102,8 @@ defmodule XmlBuilder do
   def generate({name, attrs, content}, level) when not is_blank_attrs(attrs) and is_list(content),
     do: "#{indent(level)}<#{name} #{generate_attributes(attrs)}>#{generate_content(content, level+1)}\n#{indent(level)}</#{name}>"
 
-  ##############################################################################
-
   defp tree_node(element_spec),
     do: element(element_spec)
-
-  ##############################################################################
 
   defp generate_content(children, level) when is_list(children),
     do: "\n" <> Enum.map_join(children, "\n", &(generate(&1, level)))
@@ -121,12 +114,8 @@ defmodule XmlBuilder do
   defp generate_attributes(attrs),
     do: Enum.map_join(attrs, " ", fn {k,v} -> "#{k}=#{quote_attribute_value(v)}" end)
 
-  ##############################################################################
-
   defp indent(level),
     do: String.duplicate("\t", level)
-
-  ##############################################################################
 
   defp quote_attribute_value(val) when not is_bitstring(val),
     do: quote_attribute_value(to_string(val))
@@ -144,8 +133,6 @@ defmodule XmlBuilder do
     end
   end
 
-  ##############################################################################
-
   defp escape({:cdata, data}) do
     "<![CDATA[#{data}]]>"
   end
@@ -159,8 +146,6 @@ defmodule XmlBuilder do
     |> String.replace("<", "&lt;")
     |> replace_ampersand
   end
-
-  ##############################################################################
 
   defp replace_ampersand(string) do
     Regex.replace(~r/&(?!lt;|gt;|quot;)/, string, "&amp;")

--- a/mix.exs
+++ b/mix.exs
@@ -3,9 +3,9 @@ defmodule XmlBuilder.Mixfile do
 
   def project do
     [app: :xml_builder,
-     version: "0.0.8",
+     version: "0.0.9",
      elixir: ">= 0.14.0",
-     deps: deps,
+     deps: deps(),
      package: [
        maintainers: ["Joshua Nussbaum"],
        licenses: ["MIT"],

--- a/test/xml_builder_test.exs
+++ b/test/xml_builder_test.exs
@@ -34,6 +34,10 @@ defmodule XmlBuilderTest do
     assert doc(:person, %{id: 123}, [{:first_name, "Josh"}, {:last_name, "Nussbaum"}]) == ~s|<?xml version="1.0" encoding="UTF-8" ?>\n<person id="123">\n\t<first_name>Josh</first_name>\n\t<last_name>Nussbaum</last_name>\n</person>|
   end
 
+  test "element with text content" do
+    assert doc(:person, ["TextNode", {:name, %{id: 123}, "Josh"}, "TextNode"]) == ~s|<?xml version="1.0" encoding="UTF-8" ?>\n<person>\n\tTextNode\n\t<name id="123">Josh</name>\n\tTextNode\n</person>|
+  end
+
   test "children elements" do
     assert doc([{:name, %{id: 123}, "Josh"}]) == ~s|<?xml version="1.0" encoding="UTF-8" ?>\n<name id="123">Josh</name>|
     assert doc([{:first_name, "Josh"}, {:last_name, "Nussbaum"}]) == ~s|<?xml version="1.0" encoding="UTF-8" ?>\n<first_name>Josh</first_name>\n<last_name>Nussbaum</last_name>|


### PR DESCRIPTION
`XML` might have text nodes:
```xml
<p>
Hello,           <!-- ⇐ HERE -->
<em>world</em>
!                <!-- ⇐ HERE -->
</p>
```
They were handled improperly. The test for the changes I made is:

```xml
test "element with text content" do
  assert doc(:person, ["TextNode", {:name, %{id: 123}, "Josh"}, "TextNode"]) == \
    ~s|<?xml version="1.0" encoding="UTF-8" ?>\n<person>\n\tTextNode\n\t<name id="123">Josh</name>\n\tTextNode\n</person>|
end
```

Also, I made some cosmetic changes.