### PR TITLE
Configuration parameter :squeeze. #13.

### DIFF
--- a/lib/xml_builder.ex
+++ b/lib/xml_builder.ex
@@ -183,7 +183,7 @@ defmodule XmlBuilder do
     do: Enum.map_join(attrs, " ", fn {name,value} -> [to_string(name), '=', quote_attribute_value(value)] end)
 
   defp indent(level),
-    do: if squeeze?(), do: "", else: String.duplicate(@indent, level)
+    do: if squeeze?(), do: @blank, else: String.duplicate(@indent, level)
 
   defp quote_attribute_value(val) when not is_bitstring(val),
     do: quote_attribute_value(to_string(val))

--- a/mix.exs
+++ b/mix.exs
@@ -3,7 +3,7 @@ defmodule XmlBuilder.Mixfile do
 
   def project do
     [app: :xml_builder,
-     version: "0.1.1",
+     version: "0.1.2",
      elixir: ">= 0.14.0",
      deps: deps(),
      package: [

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,1 +1,1 @@
-ExUnit.start()
+ExUnit.start(exclude: :squeezed)

--- a/test/xml_builder_test.exs
+++ b/test/xml_builder_test.exs
@@ -2,7 +2,7 @@ defmodule XmlBuilderTest do
   use ExUnit.Case
   doctest XmlBuilder
 
-  import XmlBuilder, only: [doc: 1, doc: 2, doc: 3, generate: 1]
+  import XmlBuilder, only: [doc: 1, doc: 2, doc: 3]
 
   test "empty element" do
     assert doc(:person) == ~s|<?xml version="1.0" encoding="UTF-8"?>\n<person/>|
@@ -68,7 +68,6 @@ defmodule XmlBuilderTest do
   test "squeezed content" do
     Application.put_env(:xml_builder, :squeeze, true)
     assert doc([{:person, %{}, [{:name, %{id: 123}, "Josh"}, {:age, %{}, "21"}]}]) == ~s|<?xml version="1.0" encoding="UTF-8"?><person><name id=\"123\">Josh</name><age>21</age></person>|
-    assert generate([{:person, %{}, [{:name, %{id: 123}, "Josh"}, {:age, %{}, "21"}]}]) == ~s|<person><name id=\"123\">Josh</name><age>21</age></person>|
     Application.put_env(:xml_builder, :squeeze, false)
   end
 

--- a/test/xml_builder_test.exs
+++ b/test/xml_builder_test.exs
@@ -2,7 +2,7 @@ defmodule XmlBuilderTest do
   use ExUnit.Case
   doctest XmlBuilder
 
-  import XmlBuilder, only: [doc: 1, doc: 2, doc: 3]
+  import XmlBuilder, only: [doc: 1, doc: 2, doc: 3, generate: 1]
 
   test "empty element" do
     assert doc(:person) == ~s|<?xml version="1.0" encoding="UTF-8"?>\n<person/>|
@@ -62,6 +62,14 @@ defmodule XmlBuilderTest do
 
   test "multi level indentation" do
     assert doc([person: [first: "Josh", last: "Nussbaum"]]) == ~s|<?xml version="1.0" encoding="UTF-8"?>\n<person>\n\t<first>Josh</first>\n\t<last>Nussbaum</last>\n</person>|
+  end
+
+  @tag :squeezed
+  test "squeezed content" do
+    Application.put_env(:xml_builder, :squeeze, true)
+    assert doc([{:person, %{}, [{:name, %{id: 123}, "Josh"}, {:age, %{}, "21"}]}]) == ~s|<?xml version="1.0" encoding="UTF-8"?><person><name id=\"123\">Josh</name><age>21</age></person>|
+    assert generate([{:person, %{}, [{:name, %{id: 123}, "Josh"}, {:age, %{}, "21"}]}]) == ~s|<person><name id=\"123\">Josh</name><age>21</age></person>|
+    Application.put_env(:xml_builder, :squeeze, false)
   end
 
   def element(name, arg),


### PR DESCRIPTION
The issue #13 is there for a year already.

There probably could be better way of implementing the feature, like an optional parameter to `XmlBuilder.generate/{1,2,3}`, but it would require a lot of changes for nothing. I decided it is not worth it.

This implementation is very straightforward: there is a configuration parameter `config :xml_builder, :squeeze, true` that sets the squeeze mode to `true`. In that mode, no whitespace is added (neither indents nor line breaks.)

Testing is a bit tricky: you might see I have introduced a tag. By default, the suite runs with this test excluded (since the config setting is global and tests are running in parallel, it influences other tests. To check this particular setting, run test suite with `mix test --only squeezed`.