### PR TITLE
Support for DOCTYPE declarations

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ Outputs
 
 ```xml
 <?xml version="1.0" encoding="UTF-8" ?>
-<!DOCTYPE greeting SYSTEM \"hello.dtd\">
+<!DOCTYPE greeting SYSTEM "hello.dtd">
 <person>Josh</person>
 ```
 

--- a/README.md
+++ b/README.md
@@ -111,25 +111,6 @@ A DOCTYPE can be declared by applying the `doctype` function at the first positi
 import XmlBuilder
 
 doc([
-  doctype("greeting", system: "hello.dtd"),
-  element(:person, "Josh")
-])
-```
-
-Outputs
-
-```xml
-<?xml version="1.0" encoding="UTF-8" ?>
-<!DOCTYPE greeting SYSTEM "hello.dtd">
-<person>Josh</person>
-```
-
-Alternatively with a public identifier:
-
-```elixir
-import XmlBuilder
-
-doc([
   doctype("html", public: ["-//W3C//DTD XHTML 1.0 Transitional//EN",
                 "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd"]), 
   element(:html, "Hello, world!")

--- a/README.md
+++ b/README.md
@@ -102,3 +102,44 @@ end
 iex> person(123, "Josh", "Nussbaum") |> generate
 "<person id=\"123\"><first>Josh</first><last>Nussbaum</last></person>"
 ```
+
+### DOCTYPE declarations
+
+A DOCTYPE can be declared by applying the `doctype` function at the first position of a list of elements in a `doc` definition:
+
+```elixir
+import XmlBuilder
+
+doc([
+  doctype("greeting", system: "hello.dtd"),
+  element(:person, "Josh")
+])
+```
+
+Outputs
+
+```xml
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE greeting SYSTEM \"hello.dtd\">
+<person>Josh</person>
+```
+
+Alternatively with a public identifier:
+
+```elixir
+import XmlBuilder
+
+doc([
+  doctype("html", public: ["-//W3C//DTD XHTML 1.0 Transitional//EN",
+                "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd"]), 
+  element(:html, "Hello, world!")
+])
+```
+
+Outputs
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html>Hello, world!</html>
+```

--- a/lib/xml_builder.ex
+++ b/lib/xml_builder.ex
@@ -111,7 +111,26 @@ defmodule XmlBuilder do
   @doc """
   Creates a DOCTYPE declaration with a system identifier.
 
-  Returns a `tuple` in the format `{:doctype, [:system, name, system_identifier}`.  
+  Returns a `tuple` in the format `{:doctype, [:system, name, system_identifier}`.
+
+  ## Example
+
+  ```elixir
+  import XmlBuilder
+
+  doc([
+    doctype("greeting", system: "hello.dtd"),
+    element(:person, "Josh")
+  ])
+  ```
+
+  Outputs
+
+  ```xml
+  <?xml version="1.0" encoding="UTF-8" ?>
+  <!DOCTYPE greeting SYSTEM "hello.dtd">
+  <person>Josh</person>
+  ```
   """
   def doctype(name, [{:system, system_identifier}]),
     do: {:doctype, [:system, name, system_identifier]}
@@ -120,6 +139,26 @@ defmodule XmlBuilder do
   Creates a DOCTYPE declaration with a public identifier.
 
   Returns a `tuple` in the format `{:doctype, [:public, name, public_identifier, system_identifier}`.  
+
+  ## Example
+
+  ```elixir
+  import XmlBuilder
+
+  doc([
+    doctype("html", public: ["-//W3C//DTD XHTML 1.0 Transitional//EN",
+                  "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd"]), 
+    element(:html, "Hello, world!")
+  ])
+  ```
+
+  Outputs
+
+  ```xml
+  <?xml version="1.0" encoding="UTF-8"?>
+  <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+  <html>Hello, world!</html>
+  ```
   """
   def doctype(name, [{:public, [public_identifier, system_identifier]}]),
     do: {:doctype, [:public, name, public_identifier, system_identifier]}

--- a/lib/xml_builder.ex
+++ b/lib/xml_builder.ex
@@ -41,15 +41,14 @@ defmodule XmlBuilder do
       iex> XmlBuilder.doc(:person, %{id: 1}, "some data")
       "<?xml version=\\\"1.0\\\" encoding=\\\"UTF-8\\\"?>\\n<person id=\\\"1\\\">some data</person>"
   """
-
   def doc(name_or_tuple),
-    do: [:_doc_type | tree_node(name_or_tuple) |> List.wrap] |> generate
+    do: [:xml_decl | tree_node(name_or_tuple) |> List.wrap] |> generate
 
   def doc(name, attrs_or_content),
-    do: [:_doc_type | [element(name, attrs_or_content)]] |> generate
+    do: [:xml_decl | [element(name, attrs_or_content)]] |> generate
 
   def doc(name, attrs, content),
-    do: [:_doc_type | [element(name, attrs, content)]] |> generate
+    do: [:xml_decl | [element(name, attrs, content)]] |> generate
 
   @doc """
   Create an XML element.
@@ -125,7 +124,7 @@ defmodule XmlBuilder do
   def generate(any),
     do: format(any, 0) |> IO.chardata_to_string
 
-  defp format(:_doc_type, 0),
+  defp format(:xml_decl, 0),
     do: ~s|<?xml version="1.0" encoding="UTF-8"?>|
 
   defp format(string, level) when is_bitstring(string),

--- a/lib/xml_builder.ex
+++ b/lib/xml_builder.ex
@@ -133,7 +133,7 @@ defmodule XmlBuilder do
   ```
   """
   def doctype(name, [{:system, system_identifier}]),
-    do: {:doctype, [:system, name, system_identifier]}
+    do: {:doctype, {:system, name, system_identifier}}
 
   @doc """
   Creates a DOCTYPE declaration with a public identifier.
@@ -161,7 +161,7 @@ defmodule XmlBuilder do
   ```
   """
   def doctype(name, [{:public, [public_identifier, system_identifier]}]),
-    do: {:doctype, [:public, name, public_identifier, system_identifier]}
+    do: {:doctype, {:public, name, public_identifier, system_identifier}}
 
   @doc """
   Generate a binary from an XML tree
@@ -182,10 +182,10 @@ defmodule XmlBuilder do
   defp format(:xml_decl, 0),
     do: ~s|<?xml version="1.0" encoding="UTF-8"?>|
 
-  defp format({:doctype, [:system, name, system]}, 0),
+  defp format({:doctype, {:system, name, system}}, 0),
     do: ['<!DOCTYPE ', to_string(name), ' SYSTEM "', to_string(system), '">']
 
-  defp format({:doctype, [:public, name, public, system]}, 0),
+  defp format({:doctype, {:public, name, public, system}}, 0),
     do: ['<!DOCTYPE ', to_string(name), ' PUBLIC "', to_string(public), '" "', to_string(system), '">']
     
   defp format(string, level) when is_bitstring(string),
@@ -221,7 +221,7 @@ defmodule XmlBuilder do
   defp elements_with_prolog(element_spec),
     do: element(element_spec)
 
-  defp first_element({:doctype, args} = doctype_decl) when is_list(args),
+  defp first_element({:doctype, args} = doctype_decl) when is_tuple(args),
     do: doctype_decl
 
   defp first_element(element_spec),

--- a/lib/xml_builder.ex
+++ b/lib/xml_builder.ex
@@ -41,8 +41,8 @@ defmodule XmlBuilder do
       iex> XmlBuilder.doc(:person, %{id: 1}, "some data")
       "<?xml version=\\\"1.0\\\" encoding=\\\"UTF-8\\\"?>\\n<person id=\\\"1\\\">some data</person>"
   """
-  def doc(name_or_tuple),
-    do: [:xml_decl | tree_node(name_or_tuple) |> List.wrap] |> generate
+  def doc(elements),
+    do: [:xml_decl | elements_with_prolog(elements) |> List.wrap] |> generate
 
   def doc(name, attrs_or_content),
     do: [:xml_decl | [element(name, attrs_or_content)]] |> generate
@@ -94,7 +94,7 @@ defmodule XmlBuilder do
     do: element({name, nil, content})
 
   def element({name, attrs, content}) when is_list(content),
-    do: {name, attrs, Enum.map(content, &tree_node/1)}
+    do: {name, attrs, Enum.map(content, &element/1)}
 
   def element({name, attrs, content}),
     do: {name, attrs, content}
@@ -107,6 +107,22 @@ defmodule XmlBuilder do
 
   def element(name, attrs, content),
     do: element({name, attrs, content})
+
+  @doc """
+  Creates a DOCTYPE declaration with a system identifier.
+
+  Returns a `tuple` in the format `{:doctype, [:system, name, system_identifier}`.  
+  """
+  def doctype(name, [{:system, system_identifier}]),
+    do: {:doctype, [:system, name, system_identifier]}
+
+  @doc """
+  Creates a DOCTYPE declaration with a public identifier.
+
+  Returns a `tuple` in the format `{:doctype, [:public, name, public_identifier, system_identifier}`.  
+  """
+  def doctype(name, [{:public, [public_identifier, system_identifier]}]),
+    do: {:doctype, [:public, name, public_identifier, system_identifier]}
 
   @doc """
   Generate a binary from an XML tree
@@ -127,6 +143,12 @@ defmodule XmlBuilder do
   defp format(:xml_decl, 0),
     do: ~s|<?xml version="1.0" encoding="UTF-8"?>|
 
+  defp format({:doctype, [:system, name, system]}, 0),
+    do: ['<!DOCTYPE ', to_string(name), ' SYSTEM "', to_string(system), '">']
+
+  defp format({:doctype, [:public, name, public, system]}, 0),
+    do: ['<!DOCTYPE ', to_string(name), ' PUBLIC "', to_string(public), '" "', to_string(system), '">']
+    
   defp format(string, level) when is_bitstring(string),
     do: format({nil, nil, string}, level)
 
@@ -154,7 +176,16 @@ defmodule XmlBuilder do
   defp format({name, attrs, content}, level) when not is_blank_attrs(attrs) and is_list(content),
     do: [indent(level), '<', to_string(name), ' ', format_attributes(attrs), '>', format_content(content, level+1), '\n', indent(level), '</', to_string(name), '>']
 
-  defp tree_node(element_spec),
+  defp elements_with_prolog([first | rest]) when length(rest) > 0,
+    do: [first_element(first) |element(rest)]
+
+  defp elements_with_prolog(element_spec),
+    do: element(element_spec)
+
+  defp first_element({:doctype, args} = doctype_decl) when is_list(args),
+    do: doctype_decl
+
+  defp first_element(element_spec),
     do: element(element_spec)
 
   defp format_content(children, level) when is_list(children),

--- a/test/xml_builder_test.exs
+++ b/test/xml_builder_test.exs
@@ -2,10 +2,21 @@ defmodule XmlBuilderTest do
   use ExUnit.Case
   doctest XmlBuilder
 
-  import XmlBuilder, only: [doc: 1, doc: 2, doc: 3]
+  import XmlBuilder, only: [doc: 1, doc: 2, doc: 3, doctype: 2]
 
   test "empty element" do
     assert doc(:person) == ~s|<?xml version="1.0" encoding="UTF-8"?>\n<person/>|
+  end
+
+  test "document with DOCTYPE declaration and a system identifier" do
+    assert doc([doctype("greeting", system: "hello.dtd"), {:greeting, "Hello, world!"}]) == 
+            ~s|<?xml version="1.0" encoding="UTF-8"?>\n<!DOCTYPE greeting SYSTEM "hello.dtd">\n<greeting>Hello, world!</greeting>|
+  end
+
+  test "document with DOCTYPE declaration and a public identifier" do
+    assert doc([doctype("html", public: ["-//W3C//DTD XHTML 1.0 Transitional//EN",
+                "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd"]), {:html, "Hello, world!"}]) == 
+            ~s|<?xml version="1.0" encoding="UTF-8"?>\n<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">\n<html>Hello, world!</html>|
   end
 
   test "element with content" do


### PR DESCRIPTION
What's called `:doc_type` in the current implementation is actually the XML declaration.
