### PR TITLE
Allow keyword lists for attributes

### DIFF
--- a/lib/xml_builder.ex
+++ b/lib/xml_builder.ex
@@ -18,11 +18,15 @@ defmodule XmlBuilder do
   """
 
   defmacrop is_blank_attrs(attrs) do
-    quote do: is_nil(unquote(attrs)) or map_size(unquote(attrs)) == 0
+    quote do: is_blank_map(unquote(attrs)) or is_blank_list(unquote(attrs))
   end
 
   defmacrop is_blank_list(list) do
     quote do: is_nil(unquote(list)) or (is_list(unquote(list)) and length(unquote(list)) == 0)
+  end
+
+  defmacrop is_blank_map(map) do
+    quote do: is_nil(unquote(map)) or (is_map(unquote(map)) and map_size(unquote(map)) == 0)
   end
 
   @doc """

--- a/test/xml_builder_test.exs
+++ b/test/xml_builder_test.exs
@@ -35,6 +35,14 @@ defmodule XmlBuilderTest do
     assert doc(:person, %{}, nil) == ~s|<?xml version="1.0" encoding="UTF-8"?>\n<person/>|
   end
 
+  test "element with ordered attributes" do
+    assert doc(:person, [occupation: "Developer", city: "Montreal"], "Josh") == ~s|<?xml version="1.0" encoding="UTF-8"?>\n<person occupation="Developer" city="Montreal">Josh</person>|
+    assert doc(:person, [occupation: "Developer", city: "Montreal"], nil) == ~s|<?xml version="1.0" encoding="UTF-8"?>\n<person occupation="Developer" city="Montreal"/>|
+    assert doc(:person, [occupation: "Developer", city: "Montreal"], nil) == ~s|<?xml version="1.0" encoding="UTF-8"?>\n<person occupation="Developer" city="Montreal"/>|
+    assert doc(:person, [], "Josh") == ~s|<?xml version="1.0" encoding="UTF-8"?>\n<person>Josh</person>|
+    assert doc(:person, [], nil) == ~s|<?xml version="1.0" encoding="UTF-8"?>\n<person/>|
+  end
+
   test "element with children" do
     assert doc(:person, [{:name, %{id: 123}, "Josh"}]) == ~s|<?xml version="1.0" encoding="UTF-8"?>\n<person>\n\t<name id="123">Josh</name>\n</person>|
     assert doc(:person, [{:first_name, "Josh"}, {:last_name, "Nussbaum"}]) == ~s|<?xml version="1.0" encoding="UTF-8"?>\n<person>\n\t<first_name>Josh</first_name>\n\t<last_name>Nussbaum</last_name>\n</person>|


### PR DESCRIPTION
Although the order of attributes shouldn't matter in XML, there may be times when it's necessary to specify the order (especially when dealing with legacy systems (unfortunately)).

This commit allows keyword lists as the second argument to the `doc` function so that the user can specify the order. Because `doc/2` where the second argument is a list already does something useful, for this use case it's necessary to use all three arguments.

Some examples:

```elixir
doc(:person, [occupation: "Developer", city: "Montreal"], nil) == ~s|<?xml version="1.0" encoding="UTF-8"?>\n<person occupation="Developer" city="Montreal"/>|

doc(:person, [occupation: "Developer", city: "Montreal"], "Josh") == ~s|<?xml version="1.0" encoding="UTF-8"?>\n<person occupation="Developer" city="Montreal">Josh</person>|
```