### PR TITLE
Add ability to override the encoding

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,27 @@ Outputs
 <html>Hello, world!</html>
 ```
 
+### Encoding
+
+While the output is always UTF-8 and has to be converted in another place, you can override the encoding statement in the xml declaration
+with the `encoding` option:
+
+```elixir
+import XmlBuilder
+
+[XmlBuilder.element(:oldschool, [])]
+|> XmlBuilder.document()
+|> XmlBuilder.generate(encoding: "ISO-8859-1")
+|> :unicode.characters_to_binary(:unicode, :latin1)
+```
+
+Outputs
+
+```xml
+<?xml version="1.0" encoding="ISO-8859-1"?>
+<oldschool/>
+```
+
 ### Formatting
 
 With indentation: `XmlBuilder.generate(doc, format: :indent)`

--- a/lib/xml_builder.ex
+++ b/lib/xml_builder.ex
@@ -214,6 +214,9 @@ defmodule XmlBuilder do
   def generate(any, options \\ []),
     do: format(any, 0, options) |> IO.chardata_to_string
 
+  defp format(:xml_decl, 0, [encoding: encoding]),
+    do: ~s|<?xml version="1.0" encoding="#{encoding}"?>|
+
   defp format(:xml_decl, 0, _options),
     do: ~s|<?xml version="1.0" encoding="UTF-8"?>|
 

--- a/test/xml_builder_test.exs
+++ b/test/xml_builder_test.exs
@@ -61,6 +61,16 @@ defmodule XmlBuilderTest do
       expectation = "<level1>\n\t<level2>test_value</level2>\n</level1>"
       assert XmlBuilder.generate(input(), whitespace: "\t") == expectation
     end
+
+    test "encoding defaults to UTF-8" do
+      expectation = ~s|<?xml version="1.0" encoding="UTF-8"?>|
+      assert XmlBuilder.generate(:xml_decl) == expectation
+    end
+
+    test "encoding option is used" do
+      expectation = ~s|<?xml version="1.0" encoding="ISO-8859-1"?>|
+      assert XmlBuilder.generate(:xml_decl, encoding: "ISO-8859-1") == expectation
+    end
   end
 
   test "element with content" do


### PR DESCRIPTION
We need to generate latin1 encoded xml for legacy systems. I thought it makes sense to make the encoding declaration configurable and leave the actual encoding to other libraries like e.g. codepagex.