### PR TITLE
Access implementation.

### DIFF
--- a/lib/xml_builder/access.ex
+++ b/lib/xml_builder/access.ex
@@ -9,9 +9,9 @@ defmodule XmlBuilder.Access do
       ...>   [XmlBuilder.Access.key(:data), XmlBuilder.Access.key(:name), XmlBuilder.Access.key()])
       "John"
 
-      iex> get_in({:persons, %{}, [{:name, %{}, "John"}, {:name, %{}, "Jane"}]},
-      ...>   [XmlBuilder.Access.key({:name, -1}), XmlBuilder.Access.key()])
-      "Jane"
+      iex> update_in({:persons, %{}, [{:name, %{}, "John"}, {:name, %{}, "Jane"}]},
+      ...>   [XmlBuilder.Access.key({:name, -1}), XmlBuilder.Access.key()], fn _ -> "Mary" end)
+      {:persons, %{}, [{:name, %{}, "John"}, {:name, %{}, "Mary"}]}
 
   Negative indices are supported, `-1` for the last element, `-2` for next to the last etc.
 
@@ -57,7 +57,7 @@ defmodule XmlBuilder.Access do
       {"John", {:person, %{id: 1}, [{:name, %{}, "Mary"}]}}
 
   """
-  @spec key(key :: maybe_ordered_key()) :: any() | {any(), any()}
+  @spec key(key :: maybe_ordered_key()) :: Access.access_fun()
 
   def key(key \\ nil)
 

--- a/lib/xml_builder/access.ex
+++ b/lib/xml_builder/access.ex
@@ -57,7 +57,8 @@ defmodule XmlBuilder.Access do
       {"John", {:person, %{id: 1}, [{:name, %{}, "Mary"}]}}
 
   """
-  @spec key(key :: maybe_ordered_key()) :: Access.access_fun()
+  @spec key(key :: maybe_ordered_key()) ::
+          Access.access_fun(data :: {atom(), map(), list() | any()}, get_value :: term)
 
   def key(key \\ nil)
 

--- a/lib/xml_builder/access.ex
+++ b/lib/xml_builder/access.ex
@@ -1,7 +1,7 @@
 defmodule XmlBuilder.Access do
   @moduledoc """
   Provides a function-based `Access` implementation. This allows to get an access
-  to deeply nested elemetns via `Kernel.get_in/2`, `Kernel.put_in/3`,
+  to deeply nested elemetns via `Kernel.get_in/2`, `Kernel.pop_in/2`, `Kernel.put_in/3`,
   `Kernel.update_in/3`, and `Kernel.get_and_update_in/3`.
 
   **Example:**

--- a/lib/xml_builder/access.ex
+++ b/lib/xml_builder/access.ex
@@ -1,0 +1,143 @@
+defmodule XmlBuilder.Access do
+  @moduledoc """
+  Provides a function-based `Access` implementation. This allows to get an access
+  to deeply nested elemetns via `Kernel.get_in/2`, `Kernel.put_in/3`,
+  `Kernel.update_in/3`, and `Kernel.get_and_update_in/3`.
+
+  **Example:**
+      iex> get_in({:person, %{id: 1}, [{:data, %{}, [{:name, %{}, "John"}]}]},
+      ...>   [XmlBuilder.Access.key(:data), XmlBuilder.Access.key(:name), XmlBuilder.Access.key()])
+      "John"
+
+      iex> get_in({:persons, %{}, [{:name, %{}, "John"}, {:name, %{}, "Jane"}]},
+      ...>   [XmlBuilder.Access.key({:name, -1}), XmlBuilder.Access.key()])
+      "Jane"
+
+  Negative indices are supported, `-1` for the last element, `-2` for next to the last etc.
+
+  """
+
+  @typedoc """
+  Nested elements of any node are in general accessible by `{name, index}` tuple.
+  When a single name atom passed as an argument, the implementation assumes
+  index zero.
+  """
+  @type maybe_ordered_key ::
+          nil | atom() | {atom(), integer() | :append | :prepend}
+
+  @doc """
+  Default `Access` function implementation accepting default values.
+
+  **Examples:**
+
+      iex> # simple value
+      iex> get_in({:person, %{id: 1}, 42}, [XmlBuilder.Access.key()])
+      42
+      iex> put_in({:person, %{id: 1}, nil}, [XmlBuilder.Access.key()], 42)
+      {:person, %{id: 1}, 42}
+      iex> update_in({:person, %{id: 1}, nil},
+      ...>   [XmlBuilder.Access.key()], fn _ -> 42 end)
+      {:person, %{id: 1}, 42}
+      iex> get_and_update_in({:person, %{id: 1}, nil},
+      ...>   [XmlBuilder.Access.key()], fn old -> {old, 42} end)
+      {nil, {:person, %{id: 1}, 42}}
+
+      iex> # nested element
+      iex> get_in({:person, %{id: 1}, [{:name, %{}, "John"}]},
+      ...>   [XmlBuilder.Access.key(:name)])
+      {:name, %{}, "John"}
+      iex> put_in({:person, %{id: 1}, [{:name, %{}, "John"}]},
+      ...>   [XmlBuilder.Access.key(:name)], "Mary")
+      {:person, %{id: 1}, [{:name, %{}, "Mary"}]}
+      iex> update_in({:person, %{id: 1}, [{:name, %{}, "John"}]},
+      ...>   [XmlBuilder.Access.key(:name)], fn _ -> "Mary" end)
+      {:person, %{id: 1}, [{:name, %{}, "Mary"}]}
+      iex> get_and_update_in({:person, %{id: 1}, [{:name, %{}, "John"}]},
+      ...>   [XmlBuilder.Access.key(:name)], fn {_, _, old} -> {old, "Mary"} end)
+      {"John", {:person, %{id: 1}, [{:name, %{}, "Mary"}]}}
+
+  """
+  @spec key(
+          key :: maybe_ordered_key(),
+          opts :: keyword()
+        ) :: any | {any(), any()}
+
+  def key(key \\ nil, opts \\ [])
+
+  def key(nil, _opts) do
+    fn
+      :get, {_name, _attrs, value}, fun ->
+        fun.(value)
+
+      :get_and_update, {name, attrs, value}, fun ->
+        case fun.(value) do
+          :pop ->
+            {value, {name, attrs, nil}}
+
+          {old, updated} ->
+            {old, {name, attrs, updated}}
+        end
+    end
+  end
+
+  def key(key, opts) when is_atom(key), do: key({key, 0}, opts)
+
+  def key({key, index}, _opts) when is_atom(key) and is_integer(index) do
+    fn
+      :get, {_name, _attrs, value}, fun when is_list(value) ->
+        {value, idx} = if index < 0, do: {Enum.reverse(value), -index - 1}, else: {value, index}
+
+        with {^key, attrs, value} <-
+               value
+               |> Enum.reduce_while({0, nil}, fn
+                 {^key, _, _} = e, {^idx, nil} -> {:halt, {idx, e}}
+                 {^key, _, _}, {idx, nil} -> {:cont, {idx + 1, nil}}
+                 _, acc -> {:cont, acc}
+               end)
+               |> elem(1) do
+          value = if index < 0 and is_list(value), do: Enum.reverse(value), else: value
+
+          fun.({key, attrs, value})
+        else
+          nil -> fun.(nil)
+        end
+
+      :get_and_update, {name, attrs, value}, fun when is_list(value) ->
+        {value, idx} = if index < 0, do: {Enum.reverse(value), -index - 1}, else: {value, index}
+
+        {updated_at, {old, updated}} =
+          Enum.reduce(value, {0, {nil, []}}, fn
+            {^key, attrs, value}, {^idx, {nil, acc}} ->
+              updated =
+                case fun.({key, attrs, value}) do
+                  :pop -> {{key, attrs, value}, acc}
+                  {old, {key, attrs, updated}} -> {old, [{key, attrs, updated} | acc]}
+                  {old, updated} -> {old, [{key, attrs, updated} | acc]}
+                end
+
+              {idx + 1, updated}
+
+            {^key, _, _} = matched, {idx, {value, acc}} ->
+              {idx + 1, {value, [matched | acc]}}
+
+            any, {idx, {value, acc}} ->
+              {idx, {value, [any | acc]}}
+          end)
+
+        updated = if index >= 0, do: Enum.reverse(updated), else: updated
+
+        if updated_at > idx do
+          {old, {name, attrs, updated}}
+        else
+          {old_value, updated_value} =
+            case fun.({key, attrs, nil}) do
+              :pop -> {{key, attrs, nil}, []}
+              {old, {key, attrs, updated}} -> {old, [{key, attrs, updated}]}
+              {old, updated} -> {old, [{key, attrs, updated}]}
+            end
+
+          {old_value, {name, attrs, updated ++ updated_value}}
+        end
+    end
+  end
+end

--- a/lib/xml_builder/access.ex
+++ b/lib/xml_builder/access.ex
@@ -23,7 +23,7 @@ defmodule XmlBuilder.Access do
   index zero.
   """
   @type maybe_ordered_key ::
-          nil | atom() | {atom(), integer() | :append | :prepend}
+          nil | atom() | {atom(), integer()}
 
   @doc """
   Default `Access` function implementation accepting default values.

--- a/lib/xml_builder/access.ex
+++ b/lib/xml_builder/access.ex
@@ -57,14 +57,11 @@ defmodule XmlBuilder.Access do
       {"John", {:person, %{id: 1}, [{:name, %{}, "Mary"}]}}
 
   """
-  @spec key(
-          key :: maybe_ordered_key(),
-          opts :: keyword()
-        ) :: any | {any(), any()}
+  @spec key(key :: maybe_ordered_key()) :: any() | {any(), any()}
 
-  def key(key \\ nil, opts \\ [])
+  def key(key \\ nil)
 
-  def key(nil, _opts) do
+  def key(nil) do
     fn
       :get, {_name, _attrs, value}, fun ->
         fun.(value)
@@ -80,9 +77,9 @@ defmodule XmlBuilder.Access do
     end
   end
 
-  def key(key, opts) when is_atom(key), do: key({key, 0}, opts)
+  def key(key) when is_atom(key), do: key({key, 0})
 
-  def key({key, index}, _opts) when is_atom(key) and is_integer(index) do
+  def key({key, index}) when is_atom(key) and is_integer(index) do
     fn
       :get, {_name, _attrs, value}, fun when is_list(value) ->
         {value, idx} = if index < 0, do: {Enum.reverse(value), -index - 1}, else: {value, index}

--- a/test/access_test.exs
+++ b/test/access_test.exs
@@ -84,4 +84,20 @@ defmodule XmlBuilder.Access.Test do
                 {:first, %{id: 12345}, "Mary"}
               ]}
   end
+
+  test "pop_in/2", %{person: person} do
+    assert pop_in(person, [
+             XmlBuilder.Access.key(:subperson),
+             XmlBuilder.Access.key(:first)
+           ]) ==
+             {{:first, %{}, "John"},
+              {:person, %{id: 12345},
+               [
+                 {:first, %{}, "Josh"},
+                 {:last, %{}, "Nussbaum"},
+                 {:first, %{}, "Jane"},
+                 {:last, %{}, "Doe"},
+                 {:subperson, %{class: "nested"}, [{:last, %{}, "Doe"}]}
+               ]}}
+  end
 end

--- a/test/access_test.exs
+++ b/test/access_test.exs
@@ -1,0 +1,87 @@
+defmodule XmlBuilder.Access.Test do
+  use ExUnit.Case, async: true
+  doctest XmlBuilder.Access
+
+  import XmlBuilder,
+    only: [doc: 1, doc: 2, doc: 3, document: 1, document: 2, document: 3, doctype: 2]
+
+  setup_all do
+    [
+      person:
+        {:person, %{id: 12345},
+         [
+           {:first, %{}, "Josh"},
+           {:last, %{}, "Nussbaum"},
+           {:first, %{}, "Jane"},
+           {:last, %{}, "Doe"},
+           {:subperson, %{class: "nested"},
+            [
+              {:first, %{}, "John"},
+              {:last, %{}, "Doe"}
+            ]}
+         ]}
+    ]
+  end
+
+  test "get_in/2", %{person: person} do
+    assert get_in(person, [
+             XmlBuilder.Access.key(:subperson),
+             XmlBuilder.Access.key(:first)
+           ]) == {:first, %{}, "John"}
+
+    assert get_in(person, [XmlBuilder.Access.key({:last, 1})]) == {:last, %{}, "Doe"}
+    assert get_in(person, [XmlBuilder.Access.key({:last, -1})]) == {:last, %{}, "Doe"}
+    assert get_in(person, [XmlBuilder.Access.key({:last, -2})]) == {:last, %{}, "Nussbaum"}
+    assert get_in(person, [XmlBuilder.Access.key({:last, -3})]) == nil
+  end
+
+  test "put_in/2", %{person: person} do
+    assert put_in(
+             person,
+             [
+               XmlBuilder.Access.key(:subperson),
+               XmlBuilder.Access.key(:first)
+             ],
+             "Mary"
+           ) ==
+             {:person, %{id: 12345},
+              [
+                {:first, %{}, "Josh"},
+                {:last, %{}, "Nussbaum"},
+                {:first, %{}, "Jane"},
+                {:last, %{}, "Doe"},
+                {:subperson, %{class: "nested"}, [{:first, %{}, "Mary"}, {:last, %{}, "Doe"}]}
+              ]}
+
+    assert put_in(person, [XmlBuilder.Access.key({:first, 1})], "Mary") ==
+             {:person, %{id: 12345},
+              [
+                {:first, %{}, "Josh"},
+                {:last, %{}, "Nussbaum"},
+                {:first, %{}, "Mary"},
+                {:last, %{}, "Doe"},
+                {:subperson, %{class: "nested"}, [{:first, %{}, "John"}, {:last, %{}, "Doe"}]}
+              ]}
+
+    assert put_in(person, [XmlBuilder.Access.key({:first, -1})], "Mary") ==
+             {:person, %{id: 12345},
+              [
+                {:first, %{}, "Josh"},
+                {:last, %{}, "Nussbaum"},
+                {:first, %{}, "Mary"},
+                {:last, %{}, "Doe"},
+                {:subperson, %{class: "nested"}, [{:first, %{}, "John"}, {:last, %{}, "Doe"}]}
+              ]}
+
+    assert put_in(person, [XmlBuilder.Access.key({:first, 2})], "Mary") ==
+             {:person, %{id: 12345},
+              [
+                {:first, %{}, "Josh"},
+                {:last, %{}, "Nussbaum"},
+                {:first, %{}, "Jane"},
+                {:last, %{}, "Doe"},
+                {:subperson, %{class: "nested"}, [{:first, %{}, "John"}, {:last, %{}, "Doe"}]},
+                {:first, %{id: 12345}, "Mary"}
+              ]}
+  end
+end


### PR DESCRIPTION
This PR provides an implementation of [`Access`](https://hexdocs.pm/elixir/Access.html) behaviour for raw (tuples) representation of XML.

It is handy to access deeply nested elements as well as building the deeply nested documents automatically.