### PR TITLE
feat: escape strings with pattern matching

### DIFF
--- a/lib/xml_builder.ex
+++ b/lib/xml_builder.ex
@@ -134,11 +134,11 @@ defmodule XmlBuilder do
     do: element({name, attrs, content})
 
   @doc """
-  Creates a DOCTYPE declaration with a system identifier.
+  Creates a DOCTYPE declaration with a system or public identifier.
+
+  ## System Example
 
   Returns a `tuple` in the format `{:doctype, [:system, name, system_identifier}`.
-
-  ## Example
 
   ```elixir
   import XmlBuilder
@@ -156,16 +156,10 @@ defmodule XmlBuilder do
   <!DOCTYPE greeting SYSTEM "hello.dtd">
   <person>Josh</person>
   ```
-  """
-  def doctype(name, [{:system, system_identifier}]),
-    do: {:doctype, {:system, name, system_identifier}}
 
-  @doc """
-  Creates a DOCTYPE declaration with a public identifier.
+  ## Public Example
 
-  Returns a `tuple` in the format `{:doctype, [:public, name, public_identifier, system_identifier}`.
-
-  ## Example
+   Returns a `tuple` in the format `{:doctype, [:public, name, public_identifier, system_identifier}`.
 
   ```elixir
   import XmlBuilder
@@ -185,6 +179,9 @@ defmodule XmlBuilder do
   <html>Hello, world!</html>
   ```
   """
+  def doctype(name, [{:system, system_identifier}]),
+    do: {:doctype, {:system, name, system_identifier}}
+
   def doctype(name, [{:public, [public_identifier, system_identifier]}]),
     do: {:doctype, {:public, name, public_identifier, system_identifier}}
 
@@ -384,23 +381,27 @@ defmodule XmlBuilder do
     end
   end
 
-  defp escape({:cdata, data}) do
-    ["<![CDATA[", data, "]]>"]
-  end
+  defp escape({:cdata, data}), do: ["<![CDATA[", data, "]]>"]
+
+  defp escape(data) when is_binary(data),
+    do: data |> escape_string() |> to_string()
 
   defp escape(data) when not is_bitstring(data),
-    do: escape(to_string(data))
+    do: data |> to_string() |> escape_string() |> to_string()
 
-  defp escape(string) do
-    string
-    |> String.replace(">", "&gt;")
-    |> String.replace("<", "&lt;")
-    |> String.replace(~s|"|, "&quot;")
-    |> String.replace("'", "&apos;")
-    |> replace_ampersand
-  end
+  defp escape_string(""), do: ""
+  defp escape_string(<<"&"::utf8, rest::binary>>), do: escape_entity(rest)
+  defp escape_string(<<"<"::utf8, rest::binary>>), do: ["&lt;" | escape_string(rest)]
+  defp escape_string(<<">"::utf8, rest::binary>>), do: ["&gt;" | escape_string(rest)]
+  defp escape_string(<<"\""::utf8, rest::binary>>), do: ["&quot;" | escape_string(rest)]
+  defp escape_string(<<"'"::utf8, rest::binary>>), do: ["&apos;" | escape_string(rest)]
+  defp escape_string(<<c::utf8, rest::binary>>), do: [c | escape_string(rest)]
 
-  defp replace_ampersand(string) do
-    Regex.replace(~r/&(?!(lt|gt|quot|apos|amp);)/, string, "&amp;")
-  end
+  defp escape_entity(<<"amp;"::utf8, rest::binary>>), do: ["&amp;" | escape_string(rest)]
+  defp escape_entity(<<"lt;"::utf8, rest::binary>>), do: ["&lt;" | escape_string(rest)]
+  defp escape_entity(<<"gt;"::utf8, rest::binary>>), do: ["&gt;" | escape_string(rest)]
+  defp escape_entity(<<"quot;"::utf8, rest::binary>>), do: ["&quot;" | escape_string(rest)]
+  defp escape_entity(<<"apos;"::utf8, rest::binary>>), do: ["&apos;" | escape_string(rest)]
+  defp escape_entity(rest), do: ["&amp;" | escape_string(rest)]
+
 end

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule XmlBuilder.Mixfile do
   def project do
     [
       app: :xml_builder,
-      version: "2.1.2",
+      version: "2.1.3",
       elixir: ">= 0.14.0",
       deps: deps(),
       package: [


### PR DESCRIPTION
This change modifies the escaping of Strings to make a single pass over the source string with pattern matching and [IO lists](https://www.bignerdranch.com/blog/elixir-and-io-lists-part-1-building-output-efficiently/), replacing the repeated regex passes. The behaviour of not escaping entities already in the string is maintained.

The new code has been property tested to ensure it generates the same output - see the [prop test](https://github.com/devstopfix/xml_builder/blob/compare-1/test/compare_test.exs#L30)

It has been benchmarked to show it runs quicker and uses less memory - see [benchmark script](https://github.com/devstopfix/xml_builder/blob/compare-1/benchmark.exs#L62)

Here is the benchmark report:

```
Operating System: Linux
CPU Information: Intel(R) Xeon(R) CPU E5-2666 v3 @ 2.90GHz
Number of Available Cores: 2
Available memory: 3.67 GB
Elixir 1.11.2
Erlang 23.1

Benchmark suite executing with the following configuration:
warmup: 2 s
time: 2 min
memory time: 2 min
parallel: 1
inputs: none specified
Estimated total run time: 8.07 min

Benchmarking pattern-match...
Benchmarking regex...

Name                    ips        average  deviation         median         99th %
pattern-match        4.10 K      243.86 μs    ±32.09%      212.75 μs      663.75 μs
regex                1.17 K      856.42 μs    ±10.13%      839.00 μs     1091.22 μs

Comparison: 
pattern-match        4.10 K
regex                1.17 K - 3.51x slower +612.56 μs

Memory usage statistics:

Name             Memory usage
pattern-match        74.09 KB
regex               144.71 KB - 1.95x memory usage +70.62 KB

**All measurements for memory usage were the same**
```