### PR TITLE
CI build with Elixir 1.6 - 1.11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,13 @@ elixir:
 otp_release:
   - '22.3.4'
 
+jobs:
+  include:
+    - elixir: '1.6'
+      otp_release: '20.3.8'
+
 env: MIX_ENV=test
 
 before_script:
+  - kerl list installations
   - mix compile --warnings-as-errors

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,10 @@ elixir:
   - 1.9
   - 1.8
   - 1.7
-  - 1.6
+
+otp_release:
+  - '22.3.4'
+
 env: MIX_ENV=test
 
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,12 @@
 language: elixir
 elixir:
-  - 1.3.0
-  - 1.4.0
+  - 1.11
+  - 1.10
+  - 1.9
+  - 1.8
+  - 1.7
+  - 1.6
 env: MIX_ENV=test
-otp_release:
-  - 19.0
+
+before_script:
+  - mix compile --warnings-as-errors

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 XML Builder
-=======
+===========
 
 [![Build Status](https://travis-ci.org/joshnuss/xml_builder.svg?branch=master)](https://travis-ci.org/joshnuss/xml_builder)
 
@@ -19,7 +19,7 @@ Add dependency to your project's `mix.exs`
 
 ```elixir
 def deps do
-  [{:xml_builder, "~> 2.1.1"}]
+  [{:xml_builder, "~> 2.1"}]
 end
 ```
 

--- a/mix.exs
+++ b/mix.exs
@@ -5,7 +5,7 @@ defmodule XmlBuilder.Mixfile do
     [
       app: :xml_builder,
       version: "2.1.4",
-      elixir: ">= 0.14.0",
+      elixir: "~> 1.6",
       deps: deps(),
       package: [
         maintainers: ["Joshua Nussbaum"],
@@ -18,22 +18,10 @@ defmodule XmlBuilder.Mixfile do
     ]
   end
 
-  # Configuration for the OTP application
-  #
-  # Type `mix help compile.app` for more information
   def application do
     [applications: []]
   end
 
-  # Dependencies can be hex.pm packages:
-  #
-  #   {:mydep, "~> 0.3.0"}
-  #
-  # Or git/path repositories:
-  #
-  #   {:mydep, git: "https://github.com/elixir-lang/mydep.git", tag: "0.1"}
-  #
-  # Type `mix help deps` for more examples and options
   defp deps do
     [{:ex_doc, github: "elixir-lang/ex_doc", only: :dev}]
   end

--- a/mix.lock
+++ b/mix.lock
@@ -1,7 +1,7 @@
 %{
-  "earmark": {:hex, :earmark, "1.4.0", "397e750b879df18198afc66505ca87ecf6a96645545585899f6185178433cc09", [:mix], [], "hexpm"},
+  "earmark": {:hex, :earmark, "1.4.0", "397e750b879df18198afc66505ca87ecf6a96645545585899f6185178433cc09", [:mix], [], "hexpm", "4bedcec35de03b5f559fd2386be24d08f7637c374d3a85d3fe0911eecdae838a"},
   "ex_doc": {:git, "https://github.com/elixir-lang/ex_doc.git", "09f1f45877befe10bf6d547f8c113c77a28c2655", []},
-  "makeup": {:hex, :makeup, "1.0.0", "671df94cf5a594b739ce03b0d0316aa64312cee2574b6a44becb83cd90fb05dc", [:mix], [{:nimble_parsec, "~> 0.5.0", [hex: :nimble_parsec, repo: "hexpm", optional: false]}], "hexpm"},
-  "makeup_elixir": {:hex, :makeup_elixir, "0.14.0", "cf8b7c66ad1cff4c14679698d532f0b5d45a3968ffbcbfd590339cb57742f1ae", [:mix], [{:makeup, "~> 1.0", [hex: :makeup, repo: "hexpm", optional: false]}], "hexpm"},
-  "nimble_parsec": {:hex, :nimble_parsec, "0.5.1", "c90796ecee0289dbb5ad16d3ad06f957b0cd1199769641c961cfe0b97db190e0", [:mix], [], "hexpm"},
+  "makeup": {:hex, :makeup, "1.0.0", "671df94cf5a594b739ce03b0d0316aa64312cee2574b6a44becb83cd90fb05dc", [:mix], [{:nimble_parsec, "~> 0.5.0", [hex: :nimble_parsec, repo: "hexpm", optional: false]}], "hexpm", "a10c6eb62cca416019663129699769f0c2ccf39428b3bb3c0cb38c718a0c186d"},
+  "makeup_elixir": {:hex, :makeup_elixir, "0.14.0", "cf8b7c66ad1cff4c14679698d532f0b5d45a3968ffbcbfd590339cb57742f1ae", [:mix], [{:makeup, "~> 1.0", [hex: :makeup, repo: "hexpm", optional: false]}], "hexpm", "d4b316c7222a85bbaa2fd7c6e90e37e953257ad196dc229505137c5e505e9eff"},
+  "nimble_parsec": {:hex, :nimble_parsec, "0.5.1", "c90796ecee0289dbb5ad16d3ad06f957b0cd1199769641c961cfe0b97db190e0", [:mix], [], "hexpm", "00e3ebdc821fb3a36957320d49e8f4bfa310d73ea31c90e5f925dc75e030da8f"},
 }


### PR DESCRIPTION
Removed OTP version from build to allow Elixir 1.6, the last supported Elixir version

(replaces similar earlier PR which got corrupted)