### PR TITLE
Fix XmlBuilder.document return documentation

### DIFF
--- a/lib/xml_builder.ex
+++ b/lib/xml_builder.ex
@@ -138,7 +138,7 @@ defmodule XmlBuilder do
 
   ## System Example
 
-  Returns a `tuple` in the format `{:doctype, [:system, name, system_identifier}`.
+  Returns a `tuple` in the format `{:doctype, {:system, name, system_identifier}}`.
 
   ```elixir
   import XmlBuilder
@@ -159,7 +159,7 @@ defmodule XmlBuilder do
 
   ## Public Example
 
-   Returns a `tuple` in the format `{:doctype, [:public, name, public_identifier, system_identifier}`.
+   Returns a `tuple` in the format `{:doctype, {:public, name, public_identifier, system_identifier}}`.
 
   ```elixir
   import XmlBuilder


### PR DESCRIPTION
While evaluating the library and looking through the docs, I noticed a small typo.