### PR TITLE
standalone false

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,6 +184,15 @@ Outputs.
 <outsider/>
 ```
 
+If otherwise you need `standalone ="false"` in the XML declaration, you can pass `standalone: false` as an option to the` generate / 2` call.
+
+Outputs.
+
+```xml
+<?xml version="1.0" standalone="false"?>
+<outsider/>
+```
+
 ### Formatting
 
 To remove indentation, pass `format: :none` option to `XmlBuilder.generate/2`.

--- a/README.md
+++ b/README.md
@@ -184,12 +184,12 @@ Outputs.
 <outsider/>
 ```
 
-If otherwise you need `standalone ="false"` in the XML declaration, you can pass `standalone: false` as an option to the` generate / 2` call.
+If otherwise you need `standalone ="no"` in the XML declaration, you can pass `standalone: false` as an option to the` generate / 2` call.
 
 Outputs.
 
 ```xml
-<?xml version="1.0" standalone="false"?>
+<?xml version="1.0" standalone="no"?>
 <outsider/>
 ```
 

--- a/lib/xml_builder.ex
+++ b/lib/xml_builder.ex
@@ -217,9 +217,10 @@ defmodule XmlBuilder do
     encoding = Keyword.get(options, :encoding, "UTF-8")
 
     standalone =
-      case Keyword.get(options, :standalone, false) do
+      case Keyword.get(options, :standalone, nil) do
         true -> ~s| standalone="yes"|
-        false -> ""
+        false -> ~s| standalone="no"|
+        nil -> ""
       end
 
     ~s|<?xml version="1.0" encoding="#{encoding}"#{standalone}?>|

--- a/test/xml_builder_test.exs
+++ b/test/xml_builder_test.exs
@@ -114,6 +114,11 @@ defmodule XmlBuilderTest do
       assert XmlBuilder.generate(:xml_decl, standalone: false) == expectation
     end
 
+    test "standalone option is omitted" do
+      expectation = ~s|<?xml version="1.0" encoding="UTF-8"?>|
+      assert XmlBuilder.generate(:xml_decl) == expectation
+    end
+
     test "standalone option works with other options" do
       xml =
         [XmlBuilder.element(:standaloneOldschool, [])]

--- a/test/xml_builder_test.exs
+++ b/test/xml_builder_test.exs
@@ -109,6 +109,11 @@ defmodule XmlBuilderTest do
       assert XmlBuilder.generate(:xml_decl, standalone: true) == expectation
     end
 
+    test "standalone option is used with false value" do
+      expectation = ~s|<?xml version="1.0" encoding="UTF-8" standalone="no"?>|
+      assert XmlBuilder.generate(:xml_decl, standalone: false) == expectation
+    end
+
     test "standalone option works with other options" do
       xml =
         [XmlBuilder.element(:standaloneOldschool, [])]


### PR DESCRIPTION
related issue https://github.com/joshnuss/xml_builder/issues/49

## Changes
- `standalone` option default vaule now is `nil` instead of `false`
- Pass a `false` value to `standalone` option now generate `standalone="no"`
- Update the readme with this behavior change.