### PR TITLE
Add `generate_iodata` and performance improvements

### DIFF
--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -8,11 +8,11 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        otp: ['22.3.4']
+        otp: ['22.3']
         elixir: ['1.11.2', '1.10.4', '1.9.4', '1.8.2', '1.7.4', '1.6.6']
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-elixir@v1
+      - uses: erlef/setup-beam@v1
         with:
           otp-version: ${{matrix.otp}}
           elixir-version: ${{matrix.elixir}}

--- a/lib/xml_builder.ex
+++ b/lib/xml_builder.ex
@@ -415,34 +415,13 @@ defmodule XmlBuilder do
   defp escape_entity(<<"apos;"::utf8, rest::binary>>), do: ["&apos;" | escape_string(rest)]
   defp escape_entity(rest), do: ["&amp;" | escape_string(rest)]
 
-  # Taken from Elixir v1.10's Enum.map_intersperse/3,
-  # to keep backwards-compatibility with older versions
-  defp map_intersperse(enumerable, separator, mapper)
-
-  defp map_intersperse(enumerable, separator, mapper) when is_list(enumerable) do
-    map_intersperse_list(enumerable, separator, mapper)
+  # Remove when support for Elixir <v1.10 is dropped
+  @compile {:inline, map_intersperse: 3}
+  if function_exported?(Enum, :map_intersperse, 3) do
+    defp map_intersperse(enumerable, separator, mapper),
+      do: Enum.map_intersperse(enumerable, separator, mapper)
+  else
+    defp map_intersperse(enumerable, separator, mapper),
+      do: enumerable |> Enum.map(mapper) |> Enum.intersperse(separator)
   end
-
-  defp map_intersperse(enumerable, separator, mapper) do
-    reduced =
-      Enum.reduce(enumerable, :first, fn
-        entry, :first -> [mapper.(entry)]
-        entry, acc -> [mapper.(entry), separator | acc]
-      end)
-
-    if reduced == :first do
-      []
-    else
-      :lists.reverse(reduced)
-    end
-  end
-
-  defp map_intersperse_list([], _, _),
-    do: []
-
-  defp map_intersperse_list([last], _, mapper),
-    do: [mapper.(last)]
-
-  defp map_intersperse_list([head | rest], separator, mapper),
-    do: [mapper.(head), separator | map_intersperse_list(rest, separator, mapper)]
 end

--- a/lib/xml_builder.ex
+++ b/lib/xml_builder.ex
@@ -29,7 +29,7 @@ defmodule XmlBuilder do
   end
 
   defmacrop is_blank_map(map) do
-    quote do: is_nil(unquote(map)) or unquote(map) == unquote(Macro.escape(%{}))
+    quote do: is_nil(unquote(map)) or unquote(map) == %{}
   end
 
   @doc """

--- a/lib/xml_builder.ex
+++ b/lib/xml_builder.ex
@@ -376,19 +376,11 @@ defmodule XmlBuilder do
     do: quote_attribute_value(to_string(val))
 
   defp quote_attribute_value(val) do
-    double = String.contains?(val, ~s|"|)
-    single = String.contains?(val, "'")
-    escaped = escape(val)
+    escape? = String.contains?(val, ["\"", "&", "<"])
 
-    cond do
-      double && single ->
-        escaped |> String.replace("\"", "&quot;") |> quote_attribute_value
-
-      double ->
-        [?', escaped, ?']
-
-      true ->
-        [?", escaped, ?"]
+    case escape? do
+      true -> [?", escape(val), ?"]
+      false -> [?", val, ?"]
     end
   end
 

--- a/test/xml_builder_test.exs
+++ b/test/xml_builder_test.exs
@@ -2,6 +2,8 @@ defmodule XmlBuilderTest do
   use ExUnit.Case
   doctest XmlBuilder
 
+  import ExUnit.CaptureIO
+
   import XmlBuilder,
     only: [doc: 1, doc: 2, doc: 3, document: 1, document: 2, document: 3, doctype: 2]
 
@@ -48,26 +50,41 @@ defmodule XmlBuilderTest do
   end
 
   test "doc with empty element" do
-    assert doc(:person) == ~s|<?xml version="1.0" encoding="UTF-8"?>\n<person/>|
+    warning =
+      capture_io(:stderr, fn ->
+        assert doc(:person) == ~s|<?xml version="1.0" encoding="UTF-8"?>\n<person/>|
+      end)
+
+    assert warning =~ "doc/1 is deprecated. Use document/1 with generate/1 instead."
   end
 
   test "doc with DOCTYPE declaration and a system identifier" do
-    assert doc([doctype("greeting", system: "hello.dtd"), {:greeting, "Hello, world!"}]) ==
-             ~s|<?xml version="1.0" encoding="UTF-8"?>\n<!DOCTYPE greeting SYSTEM "hello.dtd">\n<greeting>Hello, world!</greeting>|
+    warning =
+      capture_io(:stderr, fn ->
+        assert doc([doctype("greeting", system: "hello.dtd"), {:greeting, "Hello, world!"}]) ==
+                 ~s|<?xml version="1.0" encoding="UTF-8"?>\n<!DOCTYPE greeting SYSTEM "hello.dtd">\n<greeting>Hello, world!</greeting>|
+      end)
+
+    assert warning =~ "doc/1 is deprecated. Use document/1 with generate/1 instead."
   end
 
   test "doc with DOCTYPE declaration and a public identifier" do
-    assert doc([
-             doctype(
-               "html",
-               public: [
-                 "-//W3C//DTD XHTML 1.0 Transitional//EN",
-                 "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd"
-               ]
-             ),
-             {:html, "Hello, world!"}
-           ]) ==
-             ~s|<?xml version="1.0" encoding="UTF-8"?>\n<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">\n<html>Hello, world!</html>|
+    warning =
+      capture_io(:stderr, fn ->
+        assert doc([
+                 doctype(
+                   "html",
+                   public: [
+                     "-//W3C//DTD XHTML 1.0 Transitional//EN",
+                     "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd"
+                   ]
+                 ),
+                 {:html, "Hello, world!"}
+               ]) ==
+                 ~s|<?xml version="1.0" encoding="UTF-8"?>\n<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">\n<html>Hello, world!</html>|
+      end)
+
+    assert warning =~ "doc/1 is deprecated. Use document/1 with generate/1 instead."
   end
 
   describe "#generate with options" do
@@ -133,73 +150,113 @@ defmodule XmlBuilderTest do
   end
 
   test "element with content" do
-    assert doc(:person, "Josh") ==
-             ~s|<?xml version="1.0" encoding="UTF-8"?>\n<person>Josh</person>|
+    warning =
+      capture_io(:stderr, fn ->
+        assert doc(:person, "Josh") ==
+                 ~s|<?xml version="1.0" encoding="UTF-8"?>\n<person>Josh</person>|
+      end)
+
+    assert warning =~ "doc/2 is deprecated. Use document/2 with generate/1 instead."
   end
 
   test "element with attributes" do
-    assert doc(:person, %{occupation: "Developer", city: "Montreal"}) ==
-             ~s|<?xml version="1.0" encoding="UTF-8"?>\n<person city="Montreal" occupation="Developer"/>|
+    warning =
+      capture_io(:stderr, fn ->
+        assert doc(:person, %{occupation: "Developer", city: "Montreal"}) ==
+                 ~s|<?xml version="1.0" encoding="UTF-8"?>\n<person city="Montreal" occupation="Developer"/>|
 
-    assert doc(:person, %{}) == ~s|<?xml version="1.0" encoding="UTF-8"?>\n<person/>|
+        assert doc(:person, %{}) == ~s|<?xml version="1.0" encoding="UTF-8"?>\n<person/>|
+      end)
+
+    assert warning =~ "doc/2 is deprecated. Use document/2 with generate/1 instead."
   end
 
   test "element with attributes and content" do
-    assert doc(:person, %{occupation: "Developer", city: "Montreal"}, "Josh") ==
-             ~s|<?xml version="1.0" encoding="UTF-8"?>\n<person city="Montreal" occupation="Developer">Josh</person>|
+    warning =
+      capture_io(:stderr, fn ->
+        assert doc(:person, %{occupation: "Developer", city: "Montreal"}, "Josh") ==
+                 ~s|<?xml version="1.0" encoding="UTF-8"?>\n<person city="Montreal" occupation="Developer">Josh</person>|
 
-    assert doc(:person, %{occupation: "Developer", city: "Montreal"}, nil) ==
-             ~s|<?xml version="1.0" encoding="UTF-8"?>\n<person city="Montreal" occupation="Developer"/>|
+        assert doc(:person, %{occupation: "Developer", city: "Montreal"}, nil) ==
+                 ~s|<?xml version="1.0" encoding="UTF-8"?>\n<person city="Montreal" occupation="Developer"/>|
 
-    assert doc(:person, %{}, "Josh") ==
-             ~s|<?xml version="1.0" encoding="UTF-8"?>\n<person>Josh</person>|
+        assert doc(:person, %{}, "Josh") ==
+                 ~s|<?xml version="1.0" encoding="UTF-8"?>\n<person>Josh</person>|
 
-    assert doc(:person, %{}, nil) == ~s|<?xml version="1.0" encoding="UTF-8"?>\n<person/>|
+        assert doc(:person, %{}, nil) == ~s|<?xml version="1.0" encoding="UTF-8"?>\n<person/>|
+      end)
+
+    assert warning =~ "doc/3 is deprecated. Use document/3 with generate/1 instead."
   end
 
   test "element with ordered attributes" do
-    assert doc(:person, [occupation: "Developer", city: "Montreal"], "Josh") ==
-             ~s|<?xml version="1.0" encoding="UTF-8"?>\n<person occupation="Developer" city="Montreal">Josh</person>|
+    warning =
+      capture_io(:stderr, fn ->
+        assert doc(:person, [occupation: "Developer", city: "Montreal"], "Josh") ==
+                 ~s|<?xml version="1.0" encoding="UTF-8"?>\n<person occupation="Developer" city="Montreal">Josh</person>|
 
-    assert doc(:person, [occupation: "Developer", city: "Montreal"], nil) ==
-             ~s|<?xml version="1.0" encoding="UTF-8"?>\n<person occupation="Developer" city="Montreal"/>|
+        assert doc(:person, [occupation: "Developer", city: "Montreal"], nil) ==
+                 ~s|<?xml version="1.0" encoding="UTF-8"?>\n<person occupation="Developer" city="Montreal"/>|
 
-    assert doc(:person, [occupation: "Developer", city: "Montreal"], nil) ==
-             ~s|<?xml version="1.0" encoding="UTF-8"?>\n<person occupation="Developer" city="Montreal"/>|
+        assert doc(:person, [occupation: "Developer", city: "Montreal"], nil) ==
+                 ~s|<?xml version="1.0" encoding="UTF-8"?>\n<person occupation="Developer" city="Montreal"/>|
 
-    assert doc(:person, [], "Josh") ==
-             ~s|<?xml version="1.0" encoding="UTF-8"?>\n<person>Josh</person>|
+        assert doc(:person, [], "Josh") ==
+                 ~s|<?xml version="1.0" encoding="UTF-8"?>\n<person>Josh</person>|
 
-    assert doc(:person, [], nil) == ~s|<?xml version="1.0" encoding="UTF-8"?>\n<person/>|
+        assert doc(:person, [], nil) == ~s|<?xml version="1.0" encoding="UTF-8"?>\n<person/>|
+      end)
+
+    assert warning =~ "doc/3 is deprecated. Use document/3 with generate/1 instead."
   end
 
   test "element with children" do
-    assert doc(:person, [{:name, %{id: 123}, "Josh"}]) ==
-             ~s|<?xml version="1.0" encoding="UTF-8"?>\n<person>\n  <name id="123">Josh</name>\n</person>|
+    warning =
+      capture_io(:stderr, fn ->
+        assert doc(:person, [{:name, %{id: 123}, "Josh"}]) ==
+                 ~s|<?xml version="1.0" encoding="UTF-8"?>\n<person>\n  <name id="123">Josh</name>\n</person>|
 
-    assert doc(:person, [{:first_name, "Josh"}, {:last_name, "Nussbaum"}]) ==
-             ~s|<?xml version="1.0" encoding="UTF-8"?>\n<person>\n  <first_name>Josh</first_name>\n  <last_name>Nussbaum</last_name>\n</person>|
+        assert doc(:person, [{:first_name, "Josh"}, {:last_name, "Nussbaum"}]) ==
+                 ~s|<?xml version="1.0" encoding="UTF-8"?>\n<person>\n  <first_name>Josh</first_name>\n  <last_name>Nussbaum</last_name>\n</person>|
+      end)
+
+    assert warning =~ "doc/2 is deprecated. Use document/2 with generate/1 instead."
   end
 
   test "element with attributes and children" do
-    assert doc(:person, %{id: 123}, [{:name, "Josh"}]) ==
-             ~s|<?xml version="1.0" encoding="UTF-8"?>\n<person id="123">\n  <name>Josh</name>\n</person>|
+    warning =
+      capture_io(:stderr, fn ->
+        assert doc(:person, %{id: 123}, [{:name, "Josh"}]) ==
+                 ~s|<?xml version="1.0" encoding="UTF-8"?>\n<person id="123">\n  <name>Josh</name>\n</person>|
 
-    assert doc(:person, %{id: 123}, [{:first_name, "Josh"}, {:last_name, "Nussbaum"}]) ==
-             ~s|<?xml version="1.0" encoding="UTF-8"?>\n<person id="123">\n  <first_name>Josh</first_name>\n  <last_name>Nussbaum</last_name>\n</person>|
+        assert doc(:person, %{id: 123}, [{:first_name, "Josh"}, {:last_name, "Nussbaum"}]) ==
+                 ~s|<?xml version="1.0" encoding="UTF-8"?>\n<person id="123">\n  <first_name>Josh</first_name>\n  <last_name>Nussbaum</last_name>\n</person>|
+      end)
+
+    assert warning =~ "doc/3 is deprecated. Use document/3 with generate/1 instead."
   end
 
   test "element with text content" do
-    assert doc(:person, ["TextNode", {:name, %{id: 123}, "Josh"}, "TextNode"]) ==
-             ~s|<?xml version="1.0" encoding="UTF-8"?>\n<person>\n  TextNode\n  <name id="123">Josh</name>\n  TextNode\n</person>|
+    warning =
+      capture_io(:stderr, fn ->
+        assert doc(:person, ["TextNode", {:name, %{id: 123}, "Josh"}, "TextNode"]) ==
+                 ~s|<?xml version="1.0" encoding="UTF-8"?>\n<person>\n  TextNode\n  <name id="123">Josh</name>\n  TextNode\n</person>|
+      end)
+
+    assert warning =~ "doc/2 is deprecated. Use document/2 with generate/1 instead."
   end
 
   test "children elements" do
-    assert doc([{:name, %{id: 123}, "Josh"}]) ==
-             ~s|<?xml version="1.0" encoding="UTF-8"?>\n<name id="123">Josh</name>|
+    warning =
+      capture_io(:stderr, fn ->
+        assert doc([{:name, %{id: 123}, "Josh"}]) ==
+                 ~s|<?xml version="1.0" encoding="UTF-8"?>\n<name id="123">Josh</name>|
 
-    assert doc([{:first_name, "Josh"}, {:last_name, "Nussbaum"}]) ==
-             ~s|<?xml version="1.0" encoding="UTF-8"?>\n<first_name>Josh</first_name>\n<last_name>Nussbaum</last_name>|
+        assert doc([{:first_name, "Josh"}, {:last_name, "Nussbaum"}]) ==
+                 ~s|<?xml version="1.0" encoding="UTF-8"?>\n<first_name>Josh</first_name>\n<last_name>Nussbaum</last_name>|
+      end)
+
+    assert warning =~ "doc/1 is deprecated. Use document/1 with generate/1 instead."
   end
 
   test "quoting and escaping attributes" do
@@ -226,8 +283,13 @@ defmodule XmlBuilderTest do
   end
 
   test "multi level indentation" do
-    assert doc(person: [first: "Josh", last: "Nussbaum"]) ==
-             ~s|<?xml version="1.0" encoding="UTF-8"?>\n<person>\n  <first>Josh</first>\n  <last>Nussbaum</last>\n</person>|
+    warning =
+      capture_io(:stderr, fn ->
+        assert doc(person: [first: "Josh", last: "Nussbaum"]) ==
+                 ~s|<?xml version="1.0" encoding="UTF-8"?>\n<person>\n  <first>Josh</first>\n  <last>Nussbaum</last>\n</person>|
+      end)
+
+    assert warning =~ "doc/1 is deprecated. Use document/1 with generate/1 instead."
   end
 
   def element(name, arg),

--- a/test/xml_builder_test.exs
+++ b/test/xml_builder_test.exs
@@ -283,6 +283,21 @@ defmodule XmlBuilderTest do
              "<person><![CDATA[john & <is ok>]]></person>"
   end
 
+  test "wrap content inside safe and skip escaping" do
+    assert element(:person, {:safe, "john & <is ok>"}) == "<person>john & <is ok></person>"
+  end
+
+  test "wrap content inside iodata and skip escaping and binary conversion" do
+    assert element(:person, {:iodata, [element(:name, "john"), element(:age, "12")]}) ==
+             "<person><name>john</name><age>12</age></person>"
+
+    assert element(:person, {:iodata, ["test", ?i, "ng 123"]}) == "<person>testing 123</person>"
+
+    assert XmlBuilder.element(:person, {:iodata, ["test", ?i, "ng 123"]})
+           |> XmlBuilder.generate_iodata() ==
+             ["", '<', "person", '>', ["test", ?i, "ng 123"], '</', "person", '>']
+  end
+
   test "multi level indentation" do
     warning =
       capture_io(:stderr, fn ->

--- a/test/xml_builder_test.exs
+++ b/test/xml_builder_test.exs
@@ -261,9 +261,10 @@ defmodule XmlBuilderTest do
 
   test "quoting and escaping attributes" do
     assert element(:person, %{height: 12}) == ~s|<person height="12"/>|
-    assert element(:person, %{height: ~s|10'|}) == ~s|<person height="10&apos;"/>|
-    assert element(:person, %{height: ~s|10"|}) == ~s|<person height='10&quot;'/>|
+    assert element(:person, %{height: ~s|10'|}) == ~s|<person height="10'"/>|
+    assert element(:person, %{height: ~s|10"|}) == ~s|<person height="10&quot;"/>|
     assert element(:person, %{height: ~s|<10'5"|}) == ~s|<person height="&lt;10&apos;5&quot;"/>|
+    assert element(:person, %{height: ~s|<10|}) == ~s|<person height="&lt;10"/>|
   end
 
   test "escaping content" do


### PR DESCRIPTION
This PR fixes a couple of smaller issues, along with introducing a new function that exposes the raw `iodata`, (or `chardata`, but I think how it's used in `xml_builder`, this is always `iodata`, as I believe all externally supplied content is `to_string`'d, but I may be wrong and  would be OK with renaming to `generate_chardata`, or altering this behaviour so it is guaranteed to output `iodata`).

Fixes:
- Uses `Enum.map_intersperse/3` (or at least, a copy of it, to keep support for Elixir versions before v1.10) instead of `Enum.map_join` or `Enum.map |> Enum.intersperse` uses.
- Silences warnings and asserts they are outputted when running tests (using ExUnit.CaptureIO)
- Replaces all string interpolation in favor of iodata/charlists
- Fixes CI by using `erlef/setup-beam@v1`, as `actions/setup-elixir` is deprecated and unmaintained.