### PR TITLE
Fix doctest format

### DIFF
--- a/lib/xml_builder.ex
+++ b/lib/xml_builder.ex
@@ -221,8 +221,8 @@ defmodule XmlBuilder do
 
   ## Examples
 
-    iex> XmlBuilder.generate_iodata(XmlBuilder.element(:person))
-    ["", '<', "person", '/>']
+      iex> XmlBuilder.generate_iodata(XmlBuilder.element(:person))
+      ["", '<', "person", '/>']
   """
   def generate_iodata(any, options \\ []), do: format(any, 0, options)
 


### PR DESCRIPTION
The current format is wrong so the generated HTML docs don't look right.

## Before

![image](https://user-images.githubusercontent.com/181187/137220149-50a385c6-40c8-452c-96ce-9b598ea6f046.png)

## After

![image](https://user-images.githubusercontent.com/181187/137220864-a2f72280-abf7-4e89-9e7b-a64a92d96c6e.png)
