### PR TITLE
Allow per-tag formatter specification

### DIFF
--- a/test/xml_builder_test.exs
+++ b/test/xml_builder_test.exs
@@ -96,6 +96,18 @@ defmodule XmlBuilderTest do
       assert XmlBuilder.generate(input(), format: :none) == expectation
     end
 
+    test "when format = keyword()" do
+      input =
+        {:pre, nil,
+         [{:code, %{class: "elixir"}, ["def foo, do: :ok", "\n", "\n", "def bar, do: :error"]}]}
+
+      expectation =
+        "<pre>\n<code class=\"elixir\">def foo, do: :ok\n\ndef bar, do: :error</code>\n</pre>"
+
+      assert XmlBuilder.generate(input, format: [*: :indented, code: :none]) ==
+               expectation
+    end
+
     test "whitespace character option is used" do
       expectation = "<level1>\n\t<level2>test_value</level2>\n</level1>"
       assert XmlBuilder.generate(input(), whitespace: "\t") == expectation

--- a/test/xml_builder_test.exs
+++ b/test/xml_builder_test.exs
@@ -104,8 +104,7 @@ defmodule XmlBuilderTest do
       expectation =
         "<pre>\n<code class=\"elixir\">def foo, do: :ok\n\ndef bar, do: :error</code>\n</pre>"
 
-      assert XmlBuilder.generate(input, format: [*: :indented, code: :none]) ==
-               expectation
+      assert XmlBuilder.generate(input, format: [*: :indented, code: :none]) == expectation
     end
 
     test "whitespace character option is used" do


### PR DESCRIPTION
When one generates _XHTML_ with this library, there is no room to choose between formats: `:indent` ruins `<pre>` code blocks inserting both `indentation`s and `line_break`s into the code.

This fully backward-compatible PR introduces an ability to specify a format as a keyword of formats on a per-tag basis:

```elixir
XmlBuilder.generate(input, format: [*: :indent, code: :none])
```

I’d appreciate this being merged so that [`md`](https://github.com/am-kantox/md) custom markdown parser that uses `XmlBuilder` as a backend to generate _XHTML_ could offer an indented generation with some exceptions.

Thanks!