### PR TITLE
Escape element content when content includes also child elements

### DIFF
--- a/lib/xml_builder.ex
+++ b/lib/xml_builder.ex
@@ -261,8 +261,8 @@ defmodule XmlBuilder do
     map_intersperse(list, formatter.line_break(), &format(&1, level, options))
   end
 
-  defp format({nil, nil, name}, level, options) when is_bitstring(name),
-    do: [indent(level, options), to_string(name)]
+  defp format({nil, nil, content}, level, options) when is_bitstring(content),
+    do: [indent(level, options), format_content(content, level, options)]
 
   defp format({nil, nil, {:iodata, iodata}}, _level, _options), do: iodata
 

--- a/test/xml_builder_test.exs
+++ b/test/xml_builder_test.exs
@@ -282,6 +282,7 @@ defmodule XmlBuilderTest do
   test "escaping content" do
     assert element(:person, "Josh") == "<person>Josh</person>"
     assert element(:person, "<Josh>") == "<person>&lt;Josh&gt;</person>"
+    assert element(:paragraph, ["I <3 Elixir ", XmlBuilder.element(:bold, "& XmlBuilder")]) == "<paragraph>\n  I &lt;3 Elixir \n  <bold>&amp; XmlBuilder</bold>\n</paragraph>"
 
     assert element(:data, ~s|1 <> 2 & 2 <> 3 "'"'|) ==
              "<data>1 &lt;&gt; 2 &amp; 2 &lt;&gt; 3 &quot;&apos;&quot;&apos;</data>"

--- a/test/xml_builder_test.exs
+++ b/test/xml_builder_test.exs
@@ -282,7 +282,9 @@ defmodule XmlBuilderTest do
   test "escaping content" do
     assert element(:person, "Josh") == "<person>Josh</person>"
     assert element(:person, "<Josh>") == "<person>&lt;Josh&gt;</person>"
-    assert element(:paragraph, ["I <3 Elixir ", XmlBuilder.element(:bold, "& XmlBuilder")]) == "<paragraph>\n  I &lt;3 Elixir \n  <bold>&amp; XmlBuilder</bold>\n</paragraph>"
+
+    assert element(:paragraph, ["I <3 Elixir ", XmlBuilder.element(:bold, "& XmlBuilder")]) ==
+             "<paragraph>\n  I &lt;3 Elixir \n  <bold>&amp; XmlBuilder</bold>\n</paragraph>"
 
     assert element(:data, ~s|1 <> 2 & 2 <> 3 "'"'|) ==
              "<data>1 &lt;&gt; 2 &amp; 2 &lt;&gt; 3 &quot;&apos;&quot;&apos;</data>"


### PR DESCRIPTION
This fixes a bug where element content is not properly escaped when the element has both text (binary) children, as well as element children.